### PR TITLE
logical_processors_available on mac returns the unknown atom

### DIFF
--- a/src/brine_nif.erl
+++ b/src/brine_nif.erl
@@ -33,12 +33,20 @@
 -define(nif_error, erlang:nif_error(not_loaded)).
 
 init() ->
-    Workers = erlang:max(1, erlang:round(erlang:system_info(logical_processors_available) * 0.5)),
+    Workers = erlang:max(1, erlang:round(get_worker_count() * 0.5)),
     case build_nif_path() of
         {ok, Path} ->
             erlang:load_nif(Path, Workers);
         Error ->
             Error
+    end.
+
+get_worker_count() ->
+    case erlang:system_info(logical_processors_available) of
+        N when is_integer(N), N > 0 ->
+            N;
+        _ ->
+            erlang:system_info(logical_processors)
     end.
 
 generate_keypair(_Caller, _Ref) ->


### PR DESCRIPTION
fallback to the logical_processors flag on mac
